### PR TITLE
make conda-env-stripped-path a little more robust

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -217,7 +217,8 @@ environment variable."
   (let* ((xp-location (expand-file-name (conda-env-location)))
          (proper-location (file-name-as-directory xp-location)))
     (-filter (lambda (p)
-               (conda--includes-path-element proper-location p))
+	       (and (not (null p))
+		    (conda--includes-path-element proper-location p)))
              path)))
 
 (defun conda-env-is-valid (name)


### PR DESCRIPTION
I was getting an odd error when I was trying to set a conda env from inside of emacs (with ``M-x conda-env-activate``). Somehow, the lambda function here in this defun was being passed "nil" as a value somewhere along the line and failing there, because ``conda--includes-path-element`` assumes that its argument is a string, and fails when called with nil. I tracked it down that far, and making this small change seemed to fix this issue for me. I'm still not entirely sure what was causing it, exactly, but I figured that if it works for me, chances are pretty good that somebody else somewhere has the same issue.