### PR TITLE
Also find environments whose names contain a dash

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -146,7 +146,7 @@ environment variable."
   "Pull the `name` property out of the YAML file at FILENAME."
   (when filename
     (let ((env-yml-contents (f-read-text filename)))
-      (if (string-match "name:[ ]*\\(\\w+\\)[ ]*$" env-yml-contents)
+      (if (string-match "name:[ ]*\\([A-z0-9-]+\\)[ ]*$" env-yml-contents)
           (match-string 1 env-yml-contents)
         nil))))
 


### PR DESCRIPTION
I think conda.el should use ["Symbol constituents"](https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Class-Table.html#Syntax-Class-Table) instead of "Word constituents". I have an environment named `hail-ci` and conda.el cannot find said environment due to this. I couldn't figure out the syntax for the symbol constituents class, but `[A-z0-9-]` should work for anyone using ASCII names for their environments. I do not know if `\w` includes other important characters.