### PR TITLE
Discard stderr on 'conda ..activate' to avoid deprecation warning

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -165,12 +165,13 @@ environment variable."
 (defun conda--get-path-prefix (env-dir)
   "Get a platform-specific path string to utilize the conda env in ENV-DIR.
 It's platform specific in that it uses the platform's native path separator."
-  (s-trim (shell-command-to-string
-                (format "conda ..activate \"%s\" \"%s\""
-                        (if (eq system-type 'windows-nt)
-                            "cmd.exe"
-                          "bash")
-                        env-dir))))
+  (s-trim (with-output-to-string (with-current-buffer standard-output
+			   (process-file shell-file-name nil '(t nil) nil shell-command-switch
+			   (format "conda ..activate \"%s\" \"%s\""
+				   (if (eq system-type 'windows-nt)
+				       "cmd.exe"
+				     "bash")
+				   env-dir))))))
 
 (defun conda-env-clear-history ()
   "Clear the history of conda environments that have been activated."


### PR DESCRIPTION
As done by https://github.com/necaris/conda.el/pull/23 and https://github.com/necaris/conda.el/pull/24 this patch tries to propose a solution to deprecation warnings introduced by latests Conda releases when using cli interface.

W.r.t. https://github.com/necaris/conda.el/pull/23 this proposal does use the same cli command but ignoring stderr.
W.r.t. https://github.com/necaris/conda.el/pull/24 this proposal does not hard-code the warning string to strip out.