### PR TITLE
Fix path stripping when deactivating an environment

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -248,15 +248,16 @@ It's platform specific in that it uses the platform's native path separator."
 
 (defun conda-env-stripped-path (path-or-path-elements)
   "Strip PATH-OR-PATH-ELEMENTS of anything inserted by the current environment, returning a list of new path elements."
-  (let ((current-env-entry (concat
-                            (file-name-as-directory
-                             (expand-file-name (conda-env-default-location)))
-                            conda-env-executables-dir))
+  (let ((current-env-entry (concat (file-name-as-directory
+				    (concat (file-name-as-directory
+					     (expand-file-name (conda-env-default-location)))
+					    conda-env-current-name))
+				   conda-env-executables-dir))
         (path-elements (if (listp path-or-path-elements)
                            path-or-path-elements
                          (s-split path-separator path-or-path-elements))))
     (-filter (lambda (e)
-               (not (s-equals? current-env-entry e)))
+               (not (s-equals? current-env-entry (directory-file-name e))))
              path-elements)))
 
 (defun conda-env-is-valid (name)

--- a/test/conda-test.el
+++ b/test/conda-test.el
@@ -117,13 +117,15 @@
 (ert-deftest test-conda-env-stripped-path ()
   (cl-letf (((symbol-function 'conda-env-default-location)
              (lambda ()
-              "/home/user/sample")))
+	       "/home/user/sample"))
+	    (conda-env-executables-dir "bin")
+	    (conda-env-current-name "env-name"))
     (should (equal (conda-env-stripped-path
-                    "/usr/bin:/usr/local/bin:/home/user/sample/bin:/home/user/anaconda/bin")
-                   "/usr/bin:/usr/local/bin:/home/user/anaconda/bin"))
+                    "/usr/bin:/usr/local/bin:/home/user/sample/env-name/bin:/home/user/anaconda/bin")
+                   (list "/usr/bin" "/usr/local/bin" "/home/user/anaconda/bin")))
     (should (equal (conda-env-stripped-path
                     "/usr/bin:/usr/local/bin:/home/user/anaconda/bin")
-                   "/usr/bin:/usr/local/bin:/home/user/anaconda/bin"))))
+                   (list "/usr/bin" "/usr/local/bin" "/home/user/anaconda/bin")))))
 
 ;; (ert-deftest test-conda-env-is-valid ()
 ;;    (should (= (+ 1 1) 1)))


### PR DESCRIPTION
Two issues fixed:

* The current environment name was missing in the path string of the filter. So
  instead of filtering `/path/to/anaconda/envs/env-name/bin` it was
  `/path/to/anaconda/envs/bin` and thus no path stripping occured.

* If in the `path-or-path-elements` the path to be stripped ends with an
  directory delimiter, no path stripping occured.