### PR TITLE
Fix #77: buffer local variable `conda-anaconda-home' not working

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -187,20 +187,21 @@ environment variable."
 It's platform specific in that it uses the platform's native path separator."
   (s-trim
    (with-output-to-string
-     (with-current-buffer standard-output
-       (let* ((conda-executable-path
-               (concat (file-name-as-directory conda-anaconda-home)
-                       (file-name-as-directory conda-env-executables-dir)
-                       "conda"))
-              (command-format-string "\"%s\" ..activate \"%s\" \"%s\"")
-              (executor (if (eq system-type 'windows-nt) "cmd.exe" "bash"))
-              (command (format command-format-string
-                               conda-executable-path
-                               executor
-                               env-dir))
-              (return-code (process-file shell-file-name nil '(t nil) nil shell-command-switch command)))
-         (unless (= 0 return-code)
-           (error (format "Error: executing command \"%s\" produced error code %d" command return-code))))))))
+     (let ((conda-anaconda-home-tmp conda-anaconda-home))
+          (with-current-buffer standard-output
+            (let* ((conda-executable-path
+                    (concat (file-name-as-directory conda-anaconda-home-tmp)
+                            (file-name-as-directory conda-env-executables-dir)
+                            "conda"))
+                   (command-format-string "\"%s\" ..activate \"%s\" \"%s\"")
+                   (executor (if (eq system-type 'windows-nt) "cmd.exe" "bash"))
+                   (command (format command-format-string
+                                    conda-executable-path
+                                    executor
+                                    env-dir))
+                   (return-code (process-file shell-file-name nil '(t nil) nil shell-command-switch command)))
+              (unless (= 0 return-code)
+                (error (format "Error: executing command \"%s\" produced error code %d" command return-code))))))))
 
 ;; "public" functions
 


### PR DESCRIPTION
I use `conda-anaconda-home-tmp` to temporarily save the current value of `conda-anaconda-home` outside `with-current-buffer` block.