### PR TITLE
Quickfix for missing paren

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -201,7 +201,7 @@ It's platform specific in that it uses the platform's native path separator."
                                     env-dir))
                    (return-code (process-file shell-file-name nil '(t nil) nil shell-command-switch command)))
               (unless (= 0 return-code)
-                (error (format "Error: executing command \"%s\" produced error code %d" command return-code))))))))
+                (error (format "Error: executing command \"%s\" produced error code %d" command return-code)))))))))
 
 ;; "public" functions
 


### PR DESCRIPTION
Most recent commit missed a paren, so package cannot be loaded
