### PR TITLE
Rename undefined variable `proper-dir` to `envs-dir`

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -263,11 +263,11 @@ It's platform specific in that it uses the platform's native path separator."
 (defun conda-env-candidates-from-dir (dir)
   "Return a list of candidate environment names from DIR."
   (let ((envs-dir (file-name-as-directory (expand-file-name dir))))
-    (if (not (file-accessible-directory-p proper-dir))
+    (if (not (file-accessible-directory-p envs-dir))
         (list) ;; an empty list of candidates
       (-filter (lambda (c)
                  (conda--env-dir-is-valid (concat envs-dir c)))
-               (directory-files proper-dir nil "^[^.]")))))
+               (directory-files envs-dir nil "^[^.]")))))
 
 (defun conda-env-stripped-path (path-or-path-elements)
   "Strip PATH-OR-PATH-ELEMENTS of anything inserted by the current environment, returning a list of new path elements."


### PR DESCRIPTION
Following PR #102 Variable `proper-dir` is undefined which causes the code to break. I've just renamed it to `proper-dir`.

*Note*: I don't know if that is the intended behaviour but at least it prevents the code to break...