### PR TITLE
Fix/deprecated conda activate command

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -128,7 +128,7 @@ environment variable."
   "Is version vector V1 greater than or equal to V2?"
   (cl-loop for x across v1
            for y across v2
-           if (> x y) return nil
+           if (> x y) return t
            finally return (>= x y)))
 
 (defun conda--supports-json-activator ()

--- a/conda.el
+++ b/conda.el
@@ -254,7 +254,7 @@ struct. At minimum, this will contain an updated PATH."
                (s-split path-separator)
                (conda-env-stripped-path)
                (s-join path-separator)))
-    (let* ((cmd (format "conda shell.posix+json deactivate %s" env-dir))
+    (let* ((cmd (format "conda shell.posix+json deactivate"))
            (output (shell-command-to-string cmd))
            ;; TODO: use `json-parse-string' on sufficiently recent Emacs
            (result (json-read-from-string output)))

--- a/conda.el
+++ b/conda.el
@@ -140,7 +140,7 @@ environment variable."
   (let ((exports (or (conda-env-params-vars-export params) '())))
     (mapc (lambda (pair)
             (message "About to set %s to %s" (car pair) (cdr pair))
-            (setenv (car pair) (cdr pair)))
+            (setenv (format "%s" (car pair)) (format "%s" (cdr pair))))
           exports)))
 
 (defun conda--set-env-gud-pdb-command-name ()


### PR DESCRIPTION
Conda.el stopped working for me after upgrading to 4.13.0 due to deprecated "conda ..activate" being removed. I saw that there was this branch to address it, but there were a few issues that kept it from working, which I address in this pull request. See issue https://github.com/necaris/conda.el/issues/107

1. The conda version test called to see if the json activator is supported is backwards.
2. "conda shell.posix+json deactivate" does not allow any more arguments now.
3. setenv was getting called directly from the results of parsed JSON, which could be symbols (like 'CONDA_PREFIX) or integers (like 1). Have to force both arguments to strings.