### PR TITLE
Add ~/.conda path to conda-home-candidates

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -33,7 +33,7 @@
   :group 'python)
 
 (defcustom conda-home-candidates
-  '("~/.anaconda3" "~/miniconda3" "~/mambaforge" "~/anaconda" "~/miniconda" "~/mamba")
+  '("~/.anaconda3" "~/miniconda3" "~/mambaforge" "~/anaconda" "~/miniconda" "~/mamba" "~/.conda")
   "Location of possible candidates for conda environment directory"
   :type '(list string)
   :group 'conda)


### PR DESCRIPTION
This path is used everywhere at work, that would be awesome if you accept to add it to the default list!