### PR TITLE
fix: check if json-parse-string available (instead of emacs version)

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -168,9 +168,14 @@ ANACONDA_HOME environment variable."
                        standard-output
                      (apply #'process-file process-file-args)))))
     (condition-case err
-        (if (version< emacs-version "27.1")
-            (json-read-from-string output)
-          (json-parse-string output :object-type 'alist :null-object nil))
+        ;; (if (version< emacs-version "27.1")
+        ;;     (json-read-from-string output)
+        ;;   (json-parse-string output :object-type 'alist :null-object nil))
+        (if (progn
+              (require 'json)
+              (fboundp 'json-parse-string))
+	    (json-parse-string output :object-type 'alist :null-object nil)
+          (json-read-from-string output))
       (error "Could not parse %s as JSON: %s" output err))))
 
 


### PR DESCRIPTION
Emacs 28 as installed from conda-forge does not have native json support yet (see https://github.com/conda-forge/emacs-feedstock/issues/59), so it seems more solid to check whether `json-parse-string` is available rather than the emacs version.
