### PR TITLE
Quote Conda command

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -145,7 +145,7 @@ Set for the lifetime of the process.")
 Cached for the lifetime of the process."
   (if (not (eq conda--installed-version nil))
       conda--installed-version
-    (let ((version-output (shell-command-to-string (format "%s -V" (conda--get-executable-path)))))
+    (let ((version-output (shell-command-to-string (format "\"%s\" -V" (conda--get-executable-path)))))
       (condition-case err
           (s-with version-output
             (s-trim)


### PR DESCRIPTION
https://github.com/doomemacs/doomemacs/issues/6658
This is the similar that I'm facing , Here is the fix for this.

On my system conda--get-executable-path retruns: "c:/Users/Anudeep Kumar/miniconda3/Scripts/conda.exe"

The problem with the previous code is that doesn't work for the username that contains space in it.
The fix is to simply add double-quotes around that path before trying to run the version command.

Thanks to @tdhock for helping me find the solution.