### PR TITLE
Guard conda activation state changes

### DIFF
--- a/conda.el
+++ b/conda.el
@@ -256,8 +256,7 @@ Set for the lifetime of the process.")
   (let ((dir (file-name-as-directory candidate)))
     (and (not (s-blank? candidate))
          (f-directory? dir)
-         (or (f-directory? (concat dir conda-env-executables-dir))
-             (f-directory? (concat dir conda-env-meta-dir))))))
+         (f-directory? (concat dir conda-env-meta-dir)))))
 
 (defun conda--filter-blanks (items)
   "Remove empty strings from ITEMS."
@@ -339,6 +338,13 @@ Otherwise use \"base\" environment if available."
   scripts-activate
   scripts-deactivate)
 
+(defun conda--ensure-params-path (params command)
+  "Return PARAMS if COMMAND produced a usable PATH."
+  (let ((path (conda-env-params-path params)))
+    (unless (and (stringp path) (not (s-blank? path)))
+      (error "Conda %s returned an invalid PATH: %S" command path))
+    params))
+
 (defun conda--call-json-subcommand (subcommand &rest subcommand-args)
   "Call Conda SUBCOMMAND with SUBCOMMAND-ARGS returning JSON.
 The most common additional argument is the environment directory."
@@ -350,41 +356,45 @@ The most common additional argument is the environment directory."
   "Return activation values for the environment in ENV-DIR.
 Returns a `conda-env-params' struct.  At minimum, this will contain an
 updated PATH."
-  (if (conda--supports-json-activator)
-      (let ((result (conda--call-json-subcommand "activate" env-dir)))
-        (make-conda-env-params
-         :path (s-join path-separator (alist-get 'PATH (alist-get 'path result)))
-         :vars-export (alist-get 'export (alist-get 'vars result))
-         :vars-set (alist-get 'set (alist-get 'vars result))
-         :vars-unset (alist-get 'unset (alist-get 'vars result))
-         :scripts-activate (alist-get 'activate (alist-get 'scripts result))
-         :scripts-deactivate  (alist-get 'deactivate (alist-get 'scripts result))))
-    (if (not (conda--supports-old-activate-format))
-        (error "Installed Conda version supports neither JSON nor the old format.  This shouldn't happen!")
-      (make-conda-env-params
-       :path (concat
-              (conda--get-deprecated-path-prefix env-dir)
-              path-separator
-              (getenv "PATH"))))))
+  (conda--ensure-params-path
+   (if (conda--supports-json-activator)
+       (let ((result (conda--call-json-subcommand "activate" env-dir)))
+         (make-conda-env-params
+          :path (s-join path-separator (alist-get 'PATH (alist-get 'path result)))
+          :vars-export (alist-get 'export (alist-get 'vars result))
+          :vars-set (alist-get 'set (alist-get 'vars result))
+          :vars-unset (alist-get 'unset (alist-get 'vars result))
+          :scripts-activate (alist-get 'activate (alist-get 'scripts result))
+          :scripts-deactivate  (alist-get 'deactivate (alist-get 'scripts result))))
+     (if (not (conda--supports-old-activate-format))
+         (error "Installed Conda version supports neither JSON nor the old format.  This shouldn't happen!")
+       (make-conda-env-params
+        :path (concat
+               (conda--get-deprecated-path-prefix env-dir)
+               path-separator
+               (getenv "PATH")))))
+   "activate"))
 
 (defun conda--get-deactivation-parameters (env-dir)
   "Return activation values for the environment in ENV-DIR.
 Returns a `conda-env-params' struct.  At minimum, this will contain an
 updated PATH."
-  (if (conda--supports-json-activator)
-      (let ((result (conda--call-json-subcommand "deactivate")))
-        (make-conda-env-params
-         :path (s-join path-separator (alist-get 'PATH (alist-get 'path result)))
-         :vars-export (alist-get 'export (alist-get 'vars result))
-         :vars-set (alist-get 'set (alist-get 'vars result))
-         :vars-unset (alist-get 'unset (alist-get 'vars result))
-         :scripts-activate (alist-get 'activate (alist-get 'scripts result))
-         :scripts-deactivate  (alist-get 'deactivate (alist-get 'scripts result))))
-    (make-conda-env-params
-     :path (s-with (getenv "PATH")
-             (s-split path-separator)
-             (conda-env-stripped-path)
-             (s-join path-separator)))))
+  (conda--ensure-params-path
+   (if (conda--supports-json-activator)
+       (let ((result (conda--call-json-subcommand "deactivate")))
+         (make-conda-env-params
+          :path (s-join path-separator (alist-get 'PATH (alist-get 'path result)))
+          :vars-export (alist-get 'export (alist-get 'vars result))
+          :vars-set (alist-get 'set (alist-get 'vars result))
+          :vars-unset (alist-get 'unset (alist-get 'vars result))
+          :scripts-activate (alist-get 'activate (alist-get 'scripts result))
+          :scripts-deactivate  (alist-get 'deactivate (alist-get 'scripts result))))
+     (make-conda-env-params
+      :path (s-with (getenv "PATH")
+              (s-split path-separator)
+              (conda-env-stripped-path)
+              (s-join path-separator))))
+   "deactivate"))
 
 (defun conda--get-deprecated-path-prefix (env-dir)
   "Get a path string to utilize the conda env in ENV-DIR.
@@ -510,10 +520,10 @@ Returns a list of new path elements."
   (interactive)
   (if (not (bound-and-true-p conda-env-current-path))
       (message "No Conda environment is active")
-    (run-hooks 'conda-predeactivate-hook)
-    (setq python-shell-virtualenv-root nil)
     (let ((params (conda--get-deactivation-parameters conda-env-current-path))
           (env-name conda-env-current-name))
+      (run-hooks 'conda-predeactivate-hook)
+      (setq python-shell-virtualenv-root nil)
       (if (not (eq nil (conda-env-params-vars-export params)))
           (conda--update-env-from-params params)
         (progn ;; otherwise we fall back to legacy heuristics
@@ -522,13 +532,13 @@ Returns a list of new path elements."
       (setq exec-path (s-split (if (eq system-type 'windows-nt) ";" ":" )
                                (conda-env-params-path params)))
       (setenv "PATH" (conda-env-params-path params))
-    (setq conda-env-current-path nil)
-    (setq conda-env-current-name nil)
-    (conda--eshell-update-path)
-    (conda--set-system-gud-pdb-command-name)
-    (run-hooks 'conda-postdeactivate-hook)
-    (when (called-interactively-p 'interactive)
-      (message "Deactivated Conda environment <%s>" env-name)))))
+      (setq conda-env-current-path nil)
+      (setq conda-env-current-name nil)
+      (conda--eshell-update-path)
+      (conda--set-system-gud-pdb-command-name)
+      (run-hooks 'conda-postdeactivate-hook)
+      (when (called-interactively-p 'interactive)
+        (message "Deactivated Conda environment <%s>" env-name)))))
 
 ;;;###autoload
 (defun conda-env-activate (&optional name)
@@ -545,27 +555,25 @@ Returns a list of new path elements."
   (let ((env-path (or path (read-directory-name "Conda environment directory: "))))
     (if (not (conda--env-dir-is-valid env-path))
         (error "Invalid conda environment path specified: %s" env-path)
-      ;; first, deactivate any existing env
-      (conda-env-deactivate)
-      ;; set the state of the environment, including setting (or re-setting)
-      ;; a buffer-local variable that allows us to skip discovery when we
-      ;; switch back into the buffer.
-      (setq conda-env-current-path env-path)
-      (setq conda-env-current-name (conda-env-dir-to-name env-path))
-      (set (make-local-variable 'conda-project-env-path) env-path)
-      ;; run hooks
-      (run-hooks 'conda-preactivate-hook)
-      ;; push it onto the history
-      (add-to-list 'conda-env-history conda-env-current-name)
       (let* ((env-dir (expand-file-name env-path))
-             (env-exec-dir (concat (file-name-as-directory env-dir)
-                                   conda-env-executables-dir)))
+             (params (conda--get-activation-parameters env-dir)))
+        ;; first, deactivate any existing env
+        (conda-env-deactivate)
+        ;; set the state of the environment, including setting (or re-setting)
+        ;; a buffer-local variable that allows us to skip discovery when we
+        ;; switch back into the buffer.
+        (setq conda-env-current-path env-path)
+        (setq conda-env-current-name (conda-env-dir-to-name env-path))
+        (set (make-local-variable 'conda-project-env-path) env-path)
+        ;; run hooks
+        (run-hooks 'conda-preactivate-hook)
+        ;; push it onto the history
+        (add-to-list 'conda-env-history conda-env-current-name)
         ;; Use pythonic to activate the environment so that anaconda-mode and
         ;; others know how to work on this
         (pythonic-activate env-dir)
         (setq python-shell-virtualenv-root env-dir)
-        (let ((params (conda--get-activation-parameters env-dir))
-	      (inhibit-message t))
+        (let ((inhibit-message t))
           (if (not (eq nil (conda-env-params-vars-export params)))
               (conda--update-env-from-params params)
             (progn ;; otherwise we fall back to legacy heuristics

--- a/test/conda-test.el
+++ b/test/conda-test.el
@@ -10,12 +10,21 @@
 
 ;; Rudimentary test to get us going
 (ert-deftest test-conda-env-candidates ()
-  (setq conda-anaconda-home "/usr/share/miniconda3")
-  (setq conda-env-home-directory "/usr/share/miniconda3")
-  ;; `setup-miniconda` creates a `test` env (activate-environment: test)
-  ;; plus the `foo` env we create in CI, so check membership not exact
-  ;; equality to stay robust across conda versions.
-  (should (member "foo" (conda-env-candidates))))
+  (let ((conda-anaconda-home "/usr/share/miniconda3"))
+    (cl-letf (((symbol-function 'conda-env-default-location)
+               (lambda () "/usr/share/miniconda3/envs"))
+              ((symbol-function 'file-accessible-directory-p)
+               (lambda (dir) (equal dir "/usr/share/miniconda3/envs/")))
+              ((symbol-function 'directory-files)
+               (lambda (&rest _args) '("foo")))
+              ((symbol-function 'f-directory?)
+               (lambda (dir)
+                 (member dir '("/usr/share/miniconda3/envs/foo/"
+                               "/usr/share/miniconda3/envs/foo/conda-meta")))))
+      (should
+       (equal
+        (conda-env-candidates)
+        '("foo"))))))
 
 ;; Not sure how to meaningfully test the below
 
@@ -164,6 +173,52 @@
 ;;      (should (equal test-conda-env-read-name-args
 ;;                     '("prompt" ("one" "two" "three") nil t nil conda-env-history "one"))))
 ;;   ))
+
+(ert-deftest test-conda--env-dir-is-valid-requires-conda-meta ()
+  (cl-letf (((symbol-function 'f-directory?)
+             (lambda (dir)
+               (member dir '("/" "/bin" "/env/" "/env/conda-meta")))))
+    (should-not (conda--env-dir-is-valid "/"))
+    (should (conda--env-dir-is-valid "/env"))))
+
+(ert-deftest test-conda--get-activation-parameters-rejects-empty-path ()
+  (cl-letf (((symbol-function 'conda--supports-json-activator) (lambda () t))
+            ((symbol-function 'conda--call-json-subcommand)
+             (lambda (&rest _args) '((path . ((PATH . nil)))))))
+    (should-error (conda--get-activation-parameters "/env"))))
+
+(ert-deftest test-conda-env-activate-path-does-not-mutate-state-on-param-error ()
+  (let ((conda-env-current-path "/old")
+        (conda-env-current-name "old")
+        (conda-env-history '("old"))
+        (python-shell-virtualenv-root "/old")
+        (old-path (getenv "PATH"))
+        (deactivate-called nil))
+    (cl-letf (((symbol-function 'conda--env-dir-is-valid) (lambda (_path) t))
+              ((symbol-function 'conda--get-activation-parameters)
+               (lambda (_path) (error "bad activation")))
+              ((symbol-function 'conda-env-deactivate)
+               (lambda () (setq deactivate-called t))))
+      (should-error (conda-env-activate-path "/new"))
+      (should-not deactivate-called)
+      (should (equal conda-env-current-path "/old"))
+      (should (equal conda-env-current-name "old"))
+      (should (equal conda-env-history '("old")))
+      (should (equal python-shell-virtualenv-root "/old"))
+      (should (equal (getenv "PATH") old-path)))))
+
+(ert-deftest test-conda-env-deactivate-does-not-mutate-state-on-param-error ()
+  (let ((conda-env-current-path "/old")
+        (conda-env-current-name "old")
+        (python-shell-virtualenv-root "/old")
+        (old-path (getenv "PATH")))
+    (cl-letf (((symbol-function 'conda--get-deactivation-parameters)
+               (lambda (_path) (error "bad deactivation"))))
+      (should-error (conda-env-deactivate))
+      (should (equal conda-env-current-path "/old"))
+      (should (equal conda-env-current-name "old"))
+      (should (equal python-shell-virtualenv-root "/old"))
+      (should (equal (getenv "PATH") old-path)))))
 
 ;; potentially interactive user-exposed functions
 

--- a/test/conda-test.el
+++ b/test/conda-test.el
@@ -10,17 +10,22 @@
 
 ;; Rudimentary test to get us going
 (ert-deftest test-conda-env-candidates ()
-  (let ((conda-anaconda-home "/usr/share/miniconda3"))
+  ;; AIDEV-NOTE: expand paths rather than hardcoding POSIX ones -- the code under
+  ;; test calls `expand-file-name', which prepends a drive letter on Windows.
+  (let* ((conda-anaconda-home (expand-file-name "/usr/share/miniconda3"))
+         (envs-dir (file-name-as-directory
+                    (expand-file-name "envs" conda-anaconda-home)))
+         (foo-dir (file-name-as-directory (concat envs-dir "foo"))))
     (cl-letf (((symbol-function 'conda-env-default-location)
-               (lambda () "/usr/share/miniconda3/envs"))
+               (lambda () envs-dir))
               ((symbol-function 'file-accessible-directory-p)
-               (lambda (dir) (equal dir "/usr/share/miniconda3/envs/")))
+               (lambda (dir) (equal dir envs-dir)))
               ((symbol-function 'directory-files)
                (lambda (&rest _args) '("foo")))
               ((symbol-function 'f-directory?)
                (lambda (dir)
-                 (member dir '("/usr/share/miniconda3/envs/foo/"
-                               "/usr/share/miniconda3/envs/foo/conda-meta")))))
+                 (member dir (list foo-dir
+                                   (concat foo-dir conda-env-meta-dir))))))
       (should
        (equal
         (conda-env-candidates)


### PR DESCRIPTION
## Summary
- require conda-meta when validating environment directories, so paths like / are rejected
- reject empty PATH values from conda activation/deactivation JSON before applying them
- fetch activation/deactivation params before mutating conda.el state
- add focused ERT coverage for these failure modes

## Verification
- emacs -Q --batch -L . -L ci -l ci/deps.el -l test/conda-test.el -f ert-run-tests-batch-and-exit
- emacs -Q --batch -L . -L ci -l ci/deps.el -f batch-byte-compile conda.el test/conda-test.el